### PR TITLE
chore: fix typo in line 8 `Mulitpurpose` -> `Multipurpose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Run on Repl.it](https://repl.it/badge/github/DeltaCoderr/KarmaBot)](https://repl.it/github/DeltaCoderr/KarmaBot)
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/DeltaCoderr/KarmaBot)
 [![](https://img.shields.io/badge/discord.js-v12.0.0--dev-blue.svg?logo=npm)](https://github.com/discordjs)
->  A Mulitpurpose Discord Bot with a Music System used by 200K+ users and more than 2000 servers.
+>  A Multipurpose Discord Bot with a Music System used by 200K+ users and more than 2000 servers.
 
 Karma Bot is a open source Discord bot coded in JavaScript with [Discord.js](https://discord.js.org) by [DeltaCoderr](https://github.com/DeltaCoderr).  
 


### PR DESCRIPTION
I accidently wrote the wrong line in the commit message. I have fixed a typo in line 8, changing `Mulitpurpose` to (->) `Multipurpose`