### PR TITLE
Add npm command

### DIFF
--- a/Commands/Fun/npm.js
+++ b/Commands/Fun/npm.js
@@ -1,0 +1,49 @@
+const { SlashCommandBuilder } = require("@discord.js/builders");
+const { EmbedBuilder } = require("discord.js");
+const config = require("../../Configs/config");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('npm')
+    .setDescription('Show information about a npm package')
+    .addStringOption((option) =>
+      option
+        .setName('package')
+        .setDescription('The package information you want to see.')
+        .setRequired(true),
+    ),
+
+  async execute(interaction) {
+    const packageName = interaction.options.getString('package');
+    const url = `https://api.npms.io/v2/search?q=${packageName}`;
+    let response;
+    try {
+      response = await fetch(url).then((res) => res.json());
+    } catch (e) {
+      return interaction.reply({
+        content: "An error occured, please try again",
+        ephermal: true,
+      });
+    }
+
+    try {
+      await interaction.deferReply();
+      const package = response.results[0].package;
+      const embed = new EmbedBuilder()
+          .setColor(config.embedcolor)
+      				.setThumbnail('https://images-ext-2.discordapp.net/external/ouvh4fn7V9pphARfI-8nQdcfnYgjHZdXWlEg2sNowyw/https/cdn.auth0.com/blog/npm-package-development/logo.png')
+      .setURL(package.links.npm)
+      .setDescription(package.description)
+      .addFields({name: 'Author :', value: package.author?.name || 'None'})
+      .addFields({name: 'Maintainers :', value: package.maintainers ? package.maintainers.map(m => m.username).join(', '): 'None'})
+      .addFields({ name: 'Version :', value: package.version})
+      .setTimestamp();
+      await interaction.editReply({embeds: [embed]});
+    } catch (e) {
+      return interaction.reply({
+        content: 'No such package found.',
+        ephermale: true,
+      })
+    }
+  },
+};

--- a/Commands/Fun/npm.js
+++ b/Commands/Fun/npm.js
@@ -4,17 +4,17 @@ const config = require("../../Configs/config");
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('npm')
-    .setDescription('Show information about a npm package')
+    .setName("npm")
+    .setDescription("Show information about a npm package")
     .addStringOption((option) =>
       option
-        .setName('package')
-        .setDescription('The package information you want to see.')
+        .setName("package")
+        .setDescription("The package information you want to see.")
         .setRequired(true),
     ),
 
   async execute(interaction) {
-    const packageName = interaction.options.getString('package');
+    const packageName = interaction.options.getString("package");
     const url = `https://api.npms.io/v2/search?q=${packageName}`;
     let response;
     try {
@@ -28,22 +28,29 @@ module.exports = {
 
     try {
       await interaction.deferReply();
-      const package = response.results[0].package;
+      const npmpkg = response.results[0].package;
       const embed = new EmbedBuilder()
-          .setColor(config.embedcolor)
-      				.setThumbnail('https://images-ext-2.discordapp.net/external/ouvh4fn7V9pphARfI-8nQdcfnYgjHZdXWlEg2sNowyw/https/cdn.auth0.com/blog/npm-package-development/logo.png')
-      .setURL(package.links.npm)
-      .setDescription(package.description)
-      .addFields({name: 'Author :', value: package.author?.name || 'None'})
-      .addFields({name: 'Maintainers :', value: package.maintainers ? package.maintainers.map(m => m.username).join(', '): 'None'})
-      .addFields({ name: 'Version :', value: package.version})
-      .setTimestamp();
-      await interaction.editReply({embeds: [embed]});
+        .setColor(config.embedcolor)
+        .setThumbnail(
+          "https://images-ext-2.discordapp.net/external/ouvh4fn7V9pphARfI-8nQdcfnYgjHZdXWlEg2sNowyw/https/cdn.auth0.com/blog/npm-package-development/logo.png",
+        )
+        .setURL(npmpkg.links.npm)
+        .setDescription(npmpkg.description)
+        .addFields({ name: "Author :", value: npmpkg.author?.name || "None" })
+        .addFields({
+          name: "Maintainers :",
+          value: npmpkg.maintainers
+            ? npmpkg.maintainers.map((m) => m.username).join(", ")
+            : "None",
+        })
+        .addFields({ name: "Version :", value: npmpkg.version })
+        .setTimestamp();
+      await interaction.editReply({ embeds: [embed] });
     } catch (e) {
       return interaction.reply({
-        content: 'No such package found.',
+        content: "No such package found.",
         ephermale: true,
-      })
+      });
     }
   },
 };


### PR DESCRIPTION
This PR adds the slash command for `/npm` command, which accepts a package name a required option. 

It will show errors if its unable to fetch anything from npm (if npm is down!) and will also show an error if no results are found that are closest to the search query. 

On successfully fetching the package, it will display the package name, version, npm link, description, author name if any and the list of maintainers as an embed.

Let me know if there needs to be any fixes or addition to the command's output.

Thank you.

